### PR TITLE
fix markdown-preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.repro
+
 # Compiled Lua sources
 luac.out
 

--- a/lua/user/lazy/plugins.lua
+++ b/lua/user/lazy/plugins.lua
@@ -399,9 +399,17 @@ return {
   },
   {
     "iamcco/markdown-preview.nvim",
-    build = "cd app && npm install",
+    cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
+    build = "cd app && yarn install",
+    init = function()
+      vim.g.mkdp_filetypes = { "markdown" }
+      vim.g.mkdp_browser = "brave-browser"
+      -- vim.g.mkdp_auto_start = 0
+      vim.g.mkdp_auto_close = 1
+      -- vim.g.mkdp_refresh_slow = 1
+      -- vim.g.mkdp_open_to_the_world = 1
+    end,
     ft = { "markdown" },
-    dependencies = { { "tyru/open-browser.vim" } },
   },
   { "mattn/vim-maketable",     ft = { "markdown" } },
 

--- a/testdata/test.md
+++ b/testdata/test.md
@@ -1,7 +1,8 @@
-#test
+# test
+
 
 | fdasf | fdsa | fds   |
------------------------
+|-------|------|-------|
 | aa    | fdas | fdasf |
 | fdsa  | jkl  | ffj   |
 | fjjj  | jjjj | jjjj  |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Markdownプレビュー機能の読み込み方法をコマンドトリガーに変更し、プレビュー時のブラウザ指定や自動クローズなどの設定を追加しました。

- **バグ修正**
  - テスト用Markdownファイルのヘッダーとテーブル書式を正しいMarkdown形式に修正しました。

- **その他**
  - `.gitignore`に`.repro`を追加し、該当ファイル・ディレクトリをGit管理対象外としました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->